### PR TITLE
fix: resolve remaining Ruff violations

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,8 +7,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from src.system.domain.config import DomainConfigIf, EnvironmentEnum
 from src.system.infrastructure.ext.logfire.config import LogfireConfigIf
-from src.system.infrastructure.repository.sqlalchemy.config import SQLAlchemyConfigIf
 from src.system.infrastructure.ext.sentry.config import SentryConfigIf
+from src.system.infrastructure.repository.sqlalchemy.config import SQLAlchemyConfigIf
 from src.system.ui.discord.config import DiscordConfigIf
 
 

--- a/src/common/di/builder.py
+++ b/src/common/di/builder.py
@@ -1,20 +1,17 @@
 import dataclasses
-from typing import TYPE_CHECKING, Generic, TypeVar
+from abc import ABC
+from typing import TYPE_CHECKING
 
 from injector import Module
 
 if TYPE_CHECKING:  # pragma: no cover
-    from abc import ABC
     from collections.abc import Iterable
 
     from injector import Binder, Scope, ScopeDecorator
 
 
-InterfaceT = TypeVar("InterfaceT", bound="ABC")
-
-
 @dataclasses.dataclass
-class BindEntry(Generic[InterfaceT]):
+class BindEntry[InterfaceT: ABC]:
     interface: type[InterfaceT]
     to: type[InterfaceT] | InterfaceT
     scope: "None | type['Scope'] | 'ScopeDecorator'" = None

--- a/src/common/di/builder.py
+++ b/src/common/di/builder.py
@@ -1,6 +1,6 @@
 import dataclasses
 from abc import ABC
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from injector import Module
 
@@ -18,7 +18,7 @@ class BindEntry[InterfaceT: ABC]:
 
 
 class ModuleBase(Module):
-    _BINDINGS: "Iterable[BindEntry[ABC]]"
+    _BINDINGS: ClassVar["Iterable[BindEntry[ABC]]"]
 
     def configure(self, binder: "Binder") -> None:
         for entry in self._BINDINGS:

--- a/src/common/di/builder.py
+++ b/src/common/di/builder.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 from injector import Module
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Union, Iterable
     from abc import ABC
+    from collections.abc import Iterable
 
-    from injector import Scope, ScopeDecorator, Binder
+    from injector import Binder, Scope, ScopeDecorator
 
 
 InterfaceT = TypeVar("InterfaceT", bound="ABC")
@@ -17,7 +17,7 @@ InterfaceT = TypeVar("InterfaceT", bound="ABC")
 class BindEntry(Generic[InterfaceT]):
     interface: type[InterfaceT]
     to: type[InterfaceT] | InterfaceT
-    scope: "Union[None, type['Scope'], 'ScopeDecorator']" = None
+    scope: "None | type['Scope'] | 'ScopeDecorator'" = None
 
 
 class ModuleBase(Module):

--- a/src/common/di/test_builder.py
+++ b/src/common/di/test_builder.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import ClassVar
 from unittest.mock import MagicMock
 
 from injector import Binder, singleton
@@ -43,7 +44,7 @@ class TestBindEntry:
 class TestModuleBase:
     def test_configure_binds_all_entries(self) -> None:
         class TestModule(ModuleBase):
-            _BINDINGS = [
+            _BINDINGS: ClassVar = [
                 BindEntry(
                     interface=MockInterface,
                     to=MockImplementation,
@@ -73,7 +74,7 @@ class TestModuleBase:
                 return 42
 
         class TestModule(ModuleBase):
-            _BINDINGS = [
+            _BINDINGS: ClassVar = [
                 BindEntry(
                     interface=MockInterface,
                     to=MockImplementation,

--- a/src/system/di/container.py
+++ b/src/system/di/container.py
@@ -1,4 +1,5 @@
-from typing import Final, Iterable
+from collections.abc import Iterable
+from typing import Final
 
 from injector import Injector, Module
 
@@ -6,14 +7,14 @@ from src.system.di.module.domain.config.pydantic import PydanticDomainConfigModu
 from src.system.di.module.infrastructure.ext.logfire.config.pydantic import (
     PydanticLogfireConfigModule,
 )
+from src.system.di.module.infrastructure.ext.sentry.config.pydantic import (
+    PydanticSentryConfigModule,
+)
 from src.system.di.module.infrastructure.repository.sqlalchemy.config.pydantic import (
     PydanticSQLAlchemyConfigModule,
 )
 from src.system.di.module.infrastructure.repository.sqlalchemy.module import (
     SARepositoryModule,
-)
-from src.system.di.module.infrastructure.ext.sentry.config.pydantic import (
-    PydanticSentryConfigModule,
 )
 from src.system.di.module.ui.discord.bot.module import DiscordBotModule
 from src.system.di.module.ui.discord.config.pydantic import PydanticDiscordConfigModule

--- a/src/system/di/module/domain/config/pydantic.py
+++ b/src/system/di/module/domain/config/pydantic.py
@@ -1,7 +1,7 @@
 from injector import SingletonScope
 
 from config import get_config_for_current_env
-from src.common.di.builder import ModuleBase, BindEntry
+from src.common.di.builder import BindEntry, ModuleBase
 from src.system.domain.config import DomainConfigIf
 
 

--- a/src/system/di/module/infrastructure/ext/sentry/config/pydantic.py
+++ b/src/system/di/module/infrastructure/ext/sentry/config/pydantic.py
@@ -1,7 +1,7 @@
 from injector import SingletonScope
 
 from config import get_config_for_current_env
-from src.common.di.builder import ModuleBase, BindEntry
+from src.common.di.builder import BindEntry, ModuleBase
 from src.system.infrastructure.ext.sentry.config import SentryConfigIf
 
 

--- a/src/system/di/module/infrastructure/repository/sqlalchemy/config/pydantic.py
+++ b/src/system/di/module/infrastructure/repository/sqlalchemy/config/pydantic.py
@@ -1,7 +1,7 @@
 from injector import SingletonScope
 
 from config import get_config_for_current_env
-from src.common.di.builder import ModuleBase, BindEntry
+from src.common.di.builder import BindEntry, ModuleBase
 from src.system.infrastructure.repository.sqlalchemy.config import SQLAlchemyConfigIf
 
 

--- a/src/system/di/module/infrastructure/repository/sqlalchemy/module.py
+++ b/src/system/di/module/infrastructure/repository/sqlalchemy/module.py
@@ -1,8 +1,8 @@
-from injector import Module, Binder, singleton, provider
+from injector import Binder, Module, provider, singleton
 from sqlalchemy.ext.asyncio import (
-    async_sessionmaker,
-    AsyncSession,
     AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
     create_async_engine,
 )
 

--- a/src/system/di/module/ui/discord/config/pydantic.py
+++ b/src/system/di/module/ui/discord/config/pydantic.py
@@ -1,8 +1,7 @@
-from config import get_config_for_current_env
-from src.common.di.builder import ModuleBase, BindEntry
-
 from injector import SingletonScope
 
+from config import get_config_for_current_env
+from src.common.di.builder import BindEntry, ModuleBase
 from src.system.ui.discord.config import DiscordConfigIf
 
 

--- a/src/system/di/test_container.py
+++ b/src/system/di/test_container.py
@@ -1,9 +1,9 @@
 from injector import Injector
 
-from src.system.domain.config import DomainConfigIf
 from src.system.di.container import DIContainer
-from src.system.infrastructure.repository.sqlalchemy.config import SQLAlchemyConfigIf
+from src.system.domain.config import DomainConfigIf
 from src.system.infrastructure.ext.sentry.config import SentryConfigIf
+from src.system.infrastructure.repository.sqlalchemy.config import SQLAlchemyConfigIf
 from src.system.ui.discord.config import DiscordConfigIf
 
 SHOULD_BE_ABLE_TO_GET: list[type] = [

--- a/src/system/domain/interface/repository/common/response.py
+++ b/src/system/domain/interface/repository/common/response.py
@@ -1,5 +1,6 @@
+from collections.abc import Iterable
 from enum import StrEnum
-from typing import Self, Iterable
+from typing import Self
 
 from pydantic import BaseModel, Field, model_validator
 

--- a/src/system/domain/interface/repository/common/test_response.py
+++ b/src/system/domain/interface/repository/common/test_response.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -90,7 +90,7 @@ class TestRepositoryResponse:
             MockDomainModel(name="test1", value=1),
             MockDomainModel(name="test2", value=2),
         ]
-        response = RepositoryResponse[List[MockDomainModel]](
+        response = RepositoryResponse[list[MockDomainModel]](
             response=models,
             is_success=RepositoryResultStatusEnum.SUCCESS,
             status=RepositoryResponseStatusEnum.READ,

--- a/src/system/domain/interface/repository/messenger.py
+++ b/src/system/domain/interface/repository/messenger.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Iterable
+from collections.abc import Iterable
 
 from src.system.domain.interface.repository.common.base import RepositoryBase
 from src.system.domain.interface.repository.common.response import RepositoryResponse

--- a/src/system/domain/interface/repository/nickname.py
+++ b/src/system/domain/interface/repository/nickname.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Iterable
+from collections.abc import Iterable
 
 from src.system.domain.interface.repository.common.base import RepositoryBase
 from src.system.domain.interface.repository.common.option import SortOrder

--- a/src/system/domain/interface/repository/user.py
+++ b/src/system/domain/interface/repository/user.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from src.system.domain.interface.repository.common.base import RepositoryBase
 from src.system.domain.interface.repository.common.response import RepositoryResponse
 from src.system.domain.model.user import User
-from src.system.domain.value.user import UserRecordID, UserID, UserMessengerRecordID
+from src.system.domain.value.user import UserID, UserMessengerRecordID, UserRecordID
 
 
 class UserRepository(RepositoryBase):

--- a/src/system/domain/model/messenger.py
+++ b/src/system/domain/model/messenger.py
@@ -1,9 +1,9 @@
 from src.system.domain.model.base import DomainModelBase
 from src.system.domain.value.messenger import (
-    MessengerRecordID,
     MessengerCreatedAt,
-    MessengerUpdatedAt,
     MessengerName,
+    MessengerRecordID,
+    MessengerUpdatedAt,
 )
 
 

--- a/src/system/domain/model/nickname.py
+++ b/src/system/domain/model/nickname.py
@@ -1,10 +1,10 @@
 from src.system.domain.model.base import DomainModelBase
 from src.system.domain.value.nickname import (
-    NicknameChangelogRecordID,
-    NicknameChangelogCreatedAt,
-    NicknameChangelogUserRecordID,
-    NicknameChangelogBefore,
     NicknameChangelogAfter,
+    NicknameChangelogBefore,
+    NicknameChangelogCreatedAt,
+    NicknameChangelogRecordID,
+    NicknameChangelogUserRecordID,
 )
 
 

--- a/src/system/domain/model/user.py
+++ b/src/system/domain/model/user.py
@@ -1,10 +1,10 @@
 from src.system.domain.model.base import DomainModelBase
 from src.system.domain.value.user import (
-    UserRecordID,
     UserCreatedAt,
-    UserUpdatedAt,
     UserID,
     UserMessengerRecordID,
+    UserRecordID,
+    UserUpdatedAt,
 )
 
 

--- a/src/system/domain/value/base/identifier.py
+++ b/src/system/domain/value/base/identifier.py
@@ -1,7 +1,7 @@
 from typing import TypeVar
-from ulid import ULID
 
-from pydantic import RootModel, Field
+from pydantic import Field, RootModel
+from ulid import ULID
 
 from src.common.interface import Interface
 from src.system.util.id import generate_ulid

--- a/src/system/infrastructure/repository/sqlalchemy/crud/messenger.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/messenger.py
@@ -1,15 +1,15 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 import logfire
 from injector import inject
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.system.domain.interface.repository.common.response import (
-    RepositoryResponse,
-    RepositoryResultStatusEnum,
-    RepositoryResponseStatusEnum,
     RepositoryFailedResponseEnum,
+    RepositoryResponse,
+    RepositoryResponseStatusEnum,
+    RepositoryResultStatusEnum,
 )
 from src.system.domain.interface.repository.messenger import MessengerRepository
 from src.system.domain.model.messenger import Messenger
@@ -51,7 +51,7 @@ class SAMessengerRepository(MessengerRepository):
                 is_success=RepositoryResultStatusEnum.ERROR,
                 status=RepositoryResponseStatusEnum.FAILED,
                 reason=RepositoryFailedResponseEnum.UNKNOWN,
-                message=f"Failed to create messenger: {str(e)}",
+                message=f"Failed to create messenger: {e!s}",
             )
 
     @logfire.instrument(span_name="SAMessengerRepository.get_all()")
@@ -79,7 +79,7 @@ class SAMessengerRepository(MessengerRepository):
                 is_success=RepositoryResultStatusEnum.ERROR,
                 status=RepositoryResponseStatusEnum.FAILED,
                 reason=RepositoryFailedResponseEnum.UNKNOWN,
-                message=f"Failed to retrieve messengers: {str(e)}",
+                message=f"Failed to retrieve messengers: {e!s}",
             )
 
     @logfire.instrument(span_name="SAMessengerRepository.get_by_name()")
@@ -113,5 +113,5 @@ class SAMessengerRepository(MessengerRepository):
                 is_success=RepositoryResultStatusEnum.ERROR,
                 status=RepositoryResponseStatusEnum.FAILED,
                 reason=RepositoryFailedResponseEnum.UNKNOWN,
-                message=f"Failed to get messenger by name: {str(e)}",
+                message=f"Failed to get messenger by name: {e!s}",
             )

--- a/src/system/infrastructure/repository/sqlalchemy/crud/messenger.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/messenger.py
@@ -2,7 +2,8 @@ from collections.abc import Iterable
 
 import logfire
 from injector import inject
-from sqlalchemy import SQLAlchemyError, select
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.system.domain.interface.repository.common.response import (

--- a/src/system/infrastructure/repository/sqlalchemy/crud/messenger.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/messenger.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 
 import logfire
 from injector import inject
-from sqlalchemy import select
+from sqlalchemy import SQLAlchemyError, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.system.domain.interface.repository.common.response import (
@@ -45,7 +45,7 @@ class SAMessengerRepository(MessengerRepository):
                     status=RepositoryResponseStatusEnum.CREATED,
                 )
 
-        except Exception as e:
+        except SQLAlchemyError as e:
             return RepositoryResponse[Messenger | None](
                 response=data,
                 is_success=RepositoryResultStatusEnum.ERROR,
@@ -73,7 +73,7 @@ class SAMessengerRepository(MessengerRepository):
                     status=RepositoryResponseStatusEnum.READ,
                 )
 
-        except Exception as e:
+        except SQLAlchemyError as e:
             return RepositoryResponse[Iterable[Messenger]](
                 response=[],
                 is_success=RepositoryResultStatusEnum.ERROR,
@@ -107,7 +107,7 @@ class SAMessengerRepository(MessengerRepository):
                     status=RepositoryResponseStatusEnum.READ,
                 )
 
-        except Exception as e:
+        except SQLAlchemyError as e:
             return RepositoryResponse[Messenger | None](
                 response=None,
                 is_success=RepositoryResultStatusEnum.ERROR,

--- a/src/system/infrastructure/repository/sqlalchemy/crud/nickname.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/nickname.py
@@ -2,7 +2,8 @@ from collections.abc import Iterable
 
 import logfire
 from injector import inject
-from sqlalchemy import SQLAlchemyError, select
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.system.domain.interface.repository.common.option import SortOrder

--- a/src/system/infrastructure/repository/sqlalchemy/crud/nickname.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/nickname.py
@@ -1,16 +1,16 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 import logfire
 from injector import inject
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.system.domain.interface.repository.common.option import SortOrder
 from src.system.domain.interface.repository.common.response import (
-    RepositoryResponse,
-    RepositoryResultStatusEnum,
-    RepositoryResponseStatusEnum,
     RepositoryFailedResponseEnum,
+    RepositoryResponse,
+    RepositoryResponseStatusEnum,
+    RepositoryResultStatusEnum,
 )
 from src.system.domain.interface.repository.nickname import NicknameChangelogRepository
 from src.system.domain.model.nickname import NicknameChangelog
@@ -56,7 +56,7 @@ class SANicknameChangelogRepository(NicknameChangelogRepository):
                 is_success=RepositoryResultStatusEnum.ERROR,
                 status=RepositoryResponseStatusEnum.FAILED,
                 reason=RepositoryFailedResponseEnum.UNKNOWN,
-                message=f"Failed to create nickname changelog: {str(e)}",
+                message=f"Failed to create nickname changelog: {e!s}",
             )
 
     @logfire.instrument(
@@ -102,5 +102,5 @@ class SANicknameChangelogRepository(NicknameChangelogRepository):
                 is_success=RepositoryResultStatusEnum.ERROR,
                 status=RepositoryResponseStatusEnum.FAILED,
                 reason=RepositoryFailedResponseEnum.UNKNOWN,
-                message=f"Failed to retrieve nickname changelogs by user_record_id: {str(e)}",
+                message=f"Failed to retrieve nickname changelogs by user_record_id: {e!s}",
             )

--- a/src/system/infrastructure/repository/sqlalchemy/crud/nickname.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/nickname.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 
 import logfire
 from injector import inject
-from sqlalchemy import select
+from sqlalchemy import SQLAlchemyError, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.system.domain.interface.repository.common.option import SortOrder
@@ -50,7 +50,7 @@ class SANicknameChangelogRepository(NicknameChangelogRepository):
                     status=RepositoryResponseStatusEnum.CREATED,
                 )
 
-        except Exception as e:
+        except SQLAlchemyError as e:
             return RepositoryResponse[NicknameChangelog | None](
                 response=data,
                 is_success=RepositoryResultStatusEnum.ERROR,
@@ -96,7 +96,7 @@ class SANicknameChangelogRepository(NicknameChangelogRepository):
                     status=RepositoryResponseStatusEnum.READ,
                 )
 
-        except Exception as e:
+        except SQLAlchemyError as e:
             return RepositoryResponse[Iterable[NicknameChangelog]](
                 response=[],
                 is_success=RepositoryResultStatusEnum.ERROR,

--- a/src/system/infrastructure/repository/sqlalchemy/crud/test_messenger.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/test_messenger.py
@@ -6,16 +6,16 @@ import pytest
 from ulid import ULID
 
 from src.system.domain.interface.repository.common.response import (
-    RepositoryResultStatusEnum,
-    RepositoryResponseStatusEnum,
     RepositoryFailedResponseEnum,
+    RepositoryResponseStatusEnum,
+    RepositoryResultStatusEnum,
 )
 from src.system.domain.model.messenger import Messenger
 from src.system.domain.value.messenger import (
-    MessengerRecordID,
     MessengerCreatedAt,
-    MessengerUpdatedAt,
     MessengerName,
+    MessengerRecordID,
+    MessengerUpdatedAt,
 )
 from src.system.infrastructure.repository.sqlalchemy.crud.messenger import (
     SAMessengerRepository,

--- a/src/system/infrastructure/repository/sqlalchemy/crud/test_messenger.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/test_messenger.py
@@ -1,8 +1,9 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 from ulid import ULID
 
 from src.system.domain.interface.repository.common.response import (
@@ -30,7 +31,7 @@ def test_ulid() -> ULID:
 
 @pytest.fixture
 def test_datetime() -> datetime:
-    return datetime(2023, 1, 1, 12, 0, 0)
+    return datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture
@@ -93,7 +94,7 @@ class TestSAMessengerRepositoryCreate:
     @pytest.mark.asyncio
     async def test_create_failure(self, domain_messenger: Messenger) -> None:
         mock_session = AsyncMock()
-        mock_session.add = MagicMock(side_effect=Exception("Database error"))
+        mock_session.add = MagicMock(side_effect=SQLAlchemyError("Database error"))
 
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(
@@ -157,7 +158,7 @@ class TestSAMessengerRepositoryGetAll:
     @pytest.mark.asyncio
     async def test_get_all_failure(self) -> None:
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(side_effect=Exception("Database error"))
+        mock_session.execute = AsyncMock(side_effect=SQLAlchemyError("Database error"))
 
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(
@@ -223,7 +224,7 @@ class TestSAMessengerRepositoryGetByName:
     @pytest.mark.asyncio
     async def test_get_by_name_failure(self) -> None:
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(side_effect=Exception("Database error"))
+        mock_session.execute = AsyncMock(side_effect=SQLAlchemyError("Database error"))
 
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(

--- a/src/system/infrastructure/repository/sqlalchemy/crud/test_nickname.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/test_nickname.py
@@ -7,17 +7,17 @@ from ulid import ULID
 
 from src.system.domain.interface.repository.common.option import SortOrder
 from src.system.domain.interface.repository.common.response import (
-    RepositoryResultStatusEnum,
-    RepositoryResponseStatusEnum,
     RepositoryFailedResponseEnum,
+    RepositoryResponseStatusEnum,
+    RepositoryResultStatusEnum,
 )
 from src.system.domain.model.nickname import NicknameChangelog
 from src.system.domain.value.nickname import (
-    NicknameChangelogRecordID,
-    NicknameChangelogCreatedAt,
-    NicknameChangelogUserRecordID,
-    NicknameChangelogBefore,
     NicknameChangelogAfter,
+    NicknameChangelogBefore,
+    NicknameChangelogCreatedAt,
+    NicknameChangelogRecordID,
+    NicknameChangelogUserRecordID,
 )
 from src.system.infrastructure.repository.sqlalchemy.crud.nickname import (
     SANicknameChangelogRepository,

--- a/src/system/infrastructure/repository/sqlalchemy/crud/test_nickname.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/test_nickname.py
@@ -1,8 +1,9 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 from ulid import ULID
 
 from src.system.domain.interface.repository.common.option import SortOrder
@@ -37,7 +38,7 @@ def test_user_record_id() -> ULID:
 
 @pytest.fixture
 def test_datetime() -> datetime:
-    return datetime(2023, 1, 1, 12, 0, 0)
+    return datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture
@@ -109,7 +110,7 @@ class TestSANicknameChangelogRepositoryCreate:
         self, domain_nickname_changelog: NicknameChangelog
     ) -> None:
         mock_session = AsyncMock()
-        mock_session.add = MagicMock(side_effect=Exception("Database error"))
+        mock_session.add = MagicMock(side_effect=SQLAlchemyError("Database error"))
 
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(
@@ -211,7 +212,7 @@ class TestSANicknameChangelogRepositoryGetByUserRecordId:
         self, test_user_record_id: ULID
     ) -> None:
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(side_effect=Exception("Database error"))
+        mock_session.execute = AsyncMock(side_effect=SQLAlchemyError("Database error"))
 
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(

--- a/src/system/infrastructure/repository/sqlalchemy/crud/test_user.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/test_user.py
@@ -6,17 +6,17 @@ import pytest
 from ulid import ULID
 
 from src.system.domain.interface.repository.common.response import (
-    RepositoryResultStatusEnum,
-    RepositoryResponseStatusEnum,
     RepositoryFailedResponseEnum,
+    RepositoryResponseStatusEnum,
+    RepositoryResultStatusEnum,
 )
 from src.system.domain.model.user import User
 from src.system.domain.value.user import (
-    UserRecordID,
     UserCreatedAt,
-    UserUpdatedAt,
-    UserMessengerRecordID,
     UserID,
+    UserMessengerRecordID,
+    UserRecordID,
+    UserUpdatedAt,
 )
 from src.system.infrastructure.repository.sqlalchemy.crud.user import SAUserRepository
 from src.system.util.id import generate_ulid

--- a/src/system/infrastructure/repository/sqlalchemy/crud/test_user.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/test_user.py
@@ -1,8 +1,9 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 from ulid import ULID
 
 from src.system.domain.interface.repository.common.response import (
@@ -34,7 +35,7 @@ def test_messenger_record_id() -> ULID:
 
 @pytest.fixture
 def test_datetime() -> datetime:
-    return datetime(2023, 1, 1, 12, 0, 0)
+    return datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture
@@ -104,7 +105,7 @@ class TestSAUserRepositoryCreate:
     @pytest.mark.asyncio
     async def test_create_failure(self, domain_user: User) -> None:
         mock_session = AsyncMock()
-        mock_session.add = MagicMock(side_effect=Exception("Database error"))
+        mock_session.add = MagicMock(side_effect=SQLAlchemyError("Database error"))
 
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(
@@ -170,7 +171,7 @@ class TestSAUserRepositoryGet:
     @pytest.mark.asyncio
     async def test_get_failure(self, test_ulid: ULID) -> None:
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(side_effect=Exception("Database error"))
+        mock_session.execute = AsyncMock(side_effect=SQLAlchemyError("Database error"))
 
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(
@@ -249,7 +250,7 @@ class TestSAUserRepositoryGetByUserIdAndMessenger:
         self, test_messenger_record_id: ULID
     ) -> None:
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(side_effect=Exception("Database error"))
+        mock_session.execute = AsyncMock(side_effect=SQLAlchemyError("Database error"))
 
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(
@@ -342,7 +343,7 @@ class TestSAUserRepositoryGetOrCreate:
         self, domain_user: User
     ) -> None:
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(side_effect=Exception("Database error"))
+        mock_session.execute = AsyncMock(side_effect=SQLAlchemyError("Database error"))
 
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(

--- a/src/system/infrastructure/repository/sqlalchemy/crud/user.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/user.py
@@ -1,17 +1,17 @@
 import logfire
 from injector import inject
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.system.domain.interface.repository.common.response import (
-    RepositoryResponse,
-    RepositoryResultStatusEnum,
-    RepositoryResponseStatusEnum,
     RepositoryFailedResponseEnum,
+    RepositoryResponse,
+    RepositoryResponseStatusEnum,
+    RepositoryResultStatusEnum,
 )
 from src.system.domain.interface.repository.user import UserRepository
 from src.system.domain.model.user import User
-from src.system.domain.value.user import UserRecordID, UserID, UserMessengerRecordID
+from src.system.domain.value.user import UserID, UserMessengerRecordID, UserRecordID
 from src.system.infrastructure.repository.sqlalchemy.model.user import User as SAUser
 from src.system.infrastructure.repository.sqlalchemy.translator.user import (
     SAUserTranslator,
@@ -47,7 +47,7 @@ class SAUserRepository(UserRepository):
                 is_success=RepositoryResultStatusEnum.ERROR,
                 status=RepositoryResponseStatusEnum.FAILED,
                 reason=RepositoryFailedResponseEnum.UNKNOWN,
-                message=f"Failed to create user: {str(e)}",
+                message=f"Failed to create user: {e!s}",
             )
 
     @logfire.instrument(span_name="SAUserRepository.get()")
@@ -79,7 +79,7 @@ class SAUserRepository(UserRepository):
                 is_success=RepositoryResultStatusEnum.ERROR,
                 status=RepositoryResponseStatusEnum.FAILED,
                 reason=RepositoryFailedResponseEnum.UNKNOWN,
-                message=f"Failed to get user: {str(e)}",
+                message=f"Failed to get user: {e!s}",
             )
 
     @logfire.instrument(span_name="SAUserRepository.get_by_user_id_and_messenger()")
@@ -116,7 +116,7 @@ class SAUserRepository(UserRepository):
                 is_success=RepositoryResultStatusEnum.ERROR,
                 status=RepositoryResponseStatusEnum.FAILED,
                 reason=RepositoryFailedResponseEnum.UNKNOWN,
-                message=f"Failed to get user by user_id and messenger: {str(e)}",
+                message=f"Failed to get user by user_id and messenger: {e!s}",
             )
 
     @logfire.instrument(span_name="SAUserRepository.get_or_create()")

--- a/src/system/infrastructure/repository/sqlalchemy/crud/user.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/user.py
@@ -1,6 +1,6 @@
 import logfire
 from injector import inject
-from sqlalchemy import select
+from sqlalchemy import SQLAlchemyError, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.system.domain.interface.repository.common.response import (
@@ -41,7 +41,7 @@ class SAUserRepository(UserRepository):
                     status=RepositoryResponseStatusEnum.CREATED,
                 )
 
-        except Exception as e:
+        except SQLAlchemyError as e:
             return RepositoryResponse[User | None](
                 response=user,
                 is_success=RepositoryResultStatusEnum.ERROR,
@@ -73,7 +73,7 @@ class SAUserRepository(UserRepository):
                     status=RepositoryResponseStatusEnum.READ,
                 )
 
-        except Exception as e:
+        except SQLAlchemyError as e:
             return RepositoryResponse[User | None](
                 response=None,
                 is_success=RepositoryResultStatusEnum.ERROR,
@@ -110,7 +110,7 @@ class SAUserRepository(UserRepository):
                     status=RepositoryResponseStatusEnum.READ,
                 )
 
-        except Exception as e:
+        except SQLAlchemyError as e:
             return RepositoryResponse[User | None](
                 response=None,
                 is_success=RepositoryResultStatusEnum.ERROR,

--- a/src/system/infrastructure/repository/sqlalchemy/crud/user.py
+++ b/src/system/infrastructure/repository/sqlalchemy/crud/user.py
@@ -1,6 +1,7 @@
 import logfire
 from injector import inject
-from sqlalchemy import SQLAlchemyError, select
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.system.domain.interface.repository.common.response import (

--- a/src/system/infrastructure/repository/sqlalchemy/model/messenger.py
+++ b/src/system/infrastructure/repository/sqlalchemy/model/messenger.py
@@ -5,8 +5,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.system.infrastructure.repository.sqlalchemy.model.base import (
     Base,
-    ULIDMixin,
     CreatedAtMixin,
+    ULIDMixin,
     UpdatedAtMixin,
 )
 

--- a/src/system/infrastructure/repository/sqlalchemy/model/nickname.py
+++ b/src/system/infrastructure/repository/sqlalchemy/model/nickname.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING
 
-from sqlalchemy import String, ForeignKey
+from sqlalchemy import ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ulid import ULID
 
 from src.system.infrastructure.repository.sqlalchemy.model.base import (
     Base,
-    ULIDMixin,
     CreatedAtMixin,
+    ULIDMixin,
 )
 from src.system.infrastructure.repository.sqlalchemy.type.ulid import ULIDColumn
 

--- a/src/system/infrastructure/repository/sqlalchemy/model/user.py
+++ b/src/system/infrastructure/repository/sqlalchemy/model/user.py
@@ -6,8 +6,8 @@ from ulid import ULID
 
 from src.system.infrastructure.repository.sqlalchemy.model.base import (
     Base,
-    ULIDMixin,
     CreatedAtMixin,
+    ULIDMixin,
     UpdatedAtMixin,
 )
 from src.system.infrastructure.repository.sqlalchemy.type.ulid import ULIDColumn

--- a/src/system/infrastructure/repository/sqlalchemy/translator/messenger.py
+++ b/src/system/infrastructure/repository/sqlalchemy/translator/messenger.py
@@ -11,10 +11,10 @@ class SAMessengerTranslator(BaseSADomainTranslator[DomainMessenger, SAMessenger]
     @staticmethod
     def to_domain(db_record: SAMessenger) -> DomainMessenger:
         from src.system.domain.value.messenger import (
-            MessengerRecordID,
             MessengerCreatedAt,
-            MessengerUpdatedAt,
             MessengerName,
+            MessengerRecordID,
+            MessengerUpdatedAt,
         )
 
         result = DomainMessenger(

--- a/src/system/infrastructure/repository/sqlalchemy/translator/nickname.py
+++ b/src/system/infrastructure/repository/sqlalchemy/translator/nickname.py
@@ -15,11 +15,11 @@ class SANicknameChangelogTranslator(
     @staticmethod
     def to_domain(db_record: SANicknameChangelog) -> DomainNicknameChangelog:
         from src.system.domain.value.nickname import (
-            NicknameChangelogRecordID,
-            NicknameChangelogCreatedAt,
-            NicknameChangelogUserRecordID,
-            NicknameChangelogBefore,
             NicknameChangelogAfter,
+            NicknameChangelogBefore,
+            NicknameChangelogCreatedAt,
+            NicknameChangelogRecordID,
+            NicknameChangelogUserRecordID,
         )
 
         result = DomainNicknameChangelog(

--- a/src/system/infrastructure/repository/sqlalchemy/translator/test_messenger.py
+++ b/src/system/infrastructure/repository/sqlalchemy/translator/test_messenger.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -28,7 +28,7 @@ def test_ulid() -> ULID:
 
 @pytest.fixture
 def test_datetime() -> datetime:
-    return datetime(2023, 1, 1, 12, 0, 0)
+    return datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture

--- a/src/system/infrastructure/repository/sqlalchemy/translator/test_messenger.py
+++ b/src/system/infrastructure/repository/sqlalchemy/translator/test_messenger.py
@@ -6,10 +6,10 @@ from ulid import ULID
 
 from src.system.domain.model.messenger import Messenger as DomainMessenger
 from src.system.domain.value.messenger import (
-    MessengerRecordID,
     MessengerCreatedAt,
-    MessengerUpdatedAt,
     MessengerName,
+    MessengerRecordID,
+    MessengerUpdatedAt,
 )
 from src.system.infrastructure.repository.sqlalchemy.model.all import load_all_sa_models
 from src.system.infrastructure.repository.sqlalchemy.model.messenger import (

--- a/src/system/infrastructure/repository/sqlalchemy/translator/test_nickname.py
+++ b/src/system/infrastructure/repository/sqlalchemy/translator/test_nickname.py
@@ -8,11 +8,11 @@ from src.system.domain.model.nickname import (
     NicknameChangelog as DomainNicknameChangelog,
 )
 from src.system.domain.value.nickname import (
-    NicknameChangelogRecordID,
-    NicknameChangelogCreatedAt,
-    NicknameChangelogUserRecordID,
-    NicknameChangelogBefore,
     NicknameChangelogAfter,
+    NicknameChangelogBefore,
+    NicknameChangelogCreatedAt,
+    NicknameChangelogRecordID,
+    NicknameChangelogUserRecordID,
 )
 from src.system.infrastructure.repository.sqlalchemy.model.all import load_all_sa_models
 from src.system.infrastructure.repository.sqlalchemy.model.nickname import (

--- a/src/system/infrastructure/repository/sqlalchemy/translator/test_nickname.py
+++ b/src/system/infrastructure/repository/sqlalchemy/translator/test_nickname.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -31,7 +31,7 @@ def test_ulid() -> ULID:
 
 @pytest.fixture
 def test_datetime() -> datetime:
-    return datetime(2023, 1, 1, 12, 0, 0)
+    return datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture

--- a/src/system/infrastructure/repository/sqlalchemy/translator/test_user.py
+++ b/src/system/infrastructure/repository/sqlalchemy/translator/test_user.py
@@ -6,11 +6,11 @@ from ulid import ULID
 
 from src.system.domain.model.user import User as DomainUser
 from src.system.domain.value.user import (
-    UserRecordID,
     UserCreatedAt,
-    UserUpdatedAt,
-    UserMessengerRecordID,
     UserID,
+    UserMessengerRecordID,
+    UserRecordID,
+    UserUpdatedAt,
 )
 from src.system.infrastructure.repository.sqlalchemy.model.all import load_all_sa_models
 from src.system.infrastructure.repository.sqlalchemy.model.user import User as SAUser

--- a/src/system/infrastructure/repository/sqlalchemy/translator/test_user.py
+++ b/src/system/infrastructure/repository/sqlalchemy/translator/test_user.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -27,7 +27,7 @@ def test_ulid() -> ULID:
 
 @pytest.fixture
 def test_datetime() -> datetime:
-    return datetime(2023, 1, 1, 12, 0, 0)
+    return datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture

--- a/src/system/infrastructure/repository/sqlalchemy/translator/user.py
+++ b/src/system/infrastructure/repository/sqlalchemy/translator/user.py
@@ -9,11 +9,11 @@ class SAUserTranslator(BaseSADomainTranslator[DomainUser, SAUser]):
     @staticmethod
     def to_domain(db_record: SAUser) -> DomainUser:
         from src.system.domain.value.user import (
-            UserRecordID,
             UserCreatedAt,
-            UserUpdatedAt,
-            UserMessengerRecordID,
             UserID,
+            UserMessengerRecordID,
+            UserRecordID,
+            UserUpdatedAt,
         )
 
         result = DomainUser(

--- a/src/system/infrastructure/repository/sqlalchemy/type/test_ulid.py
+++ b/src/system/infrastructure/repository/sqlalchemy/type/test_ulid.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String, Dialect
+from sqlalchemy import Dialect, String
 from ulid import ULID
 
 from src.system.infrastructure.repository.sqlalchemy.type.ulid import ULIDColumn

--- a/src/system/infrastructure/repository/sqlalchemy/type/ulid.py
+++ b/src/system/infrastructure/repository/sqlalchemy/type/ulid.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String, TypeDecorator, Dialect
+from sqlalchemy import Dialect, String, TypeDecorator
 from ulid import ULID
 
 

--- a/src/system/ui/discord/bot.py
+++ b/src/system/ui/discord/bot.py
@@ -4,8 +4,8 @@ from injector import inject
 
 from src.system.domain.value.messenger import MessengerName
 from src.system.domain.value.nickname import (
-    NicknameChangelogBefore,
     NicknameChangelogAfter,
+    NicknameChangelogBefore,
 )
 from src.system.domain.value.user import UserID
 from src.system.ui.discord.config import DiscordConfigIf

--- a/src/system/ui/discord/test_bot.py
+++ b/src/system/ui/discord/test_bot.py
@@ -2,8 +2,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.system.usecase.nickname.dto import RecordNicknameChangeResponse
 from src.system.ui.discord.bot import DiscordBot
+from src.system.usecase.nickname.dto import RecordNicknameChangeResponse
 
 
 @pytest.fixture

--- a/src/system/usecase/base/interface.py
+++ b/src/system/usecase/base/interface.py
@@ -17,4 +17,4 @@ class UsecaseIf[RequestT: UsecaseRequest, ResponseT: UsecaseResponse](Interface)
         Returns:
             The use case response.
         """
-        pass  # pragma: no cover
+        # pragma: no cover

--- a/src/system/usecase/nickname/dto.py
+++ b/src/system/usecase/nickname/dto.py
@@ -2,8 +2,8 @@ from pydantic import Field
 
 from src.system.domain.value.messenger import MessengerName
 from src.system.domain.value.nickname import (
-    NicknameChangelogBefore,
     NicknameChangelogAfter,
+    NicknameChangelogBefore,
 )
 from src.system.domain.value.user import UserID
 from src.system.usecase.base.dto import UsecaseRequest, UsecaseResponse

--- a/src/system/usecase/nickname/interface.py
+++ b/src/system/usecase/nickname/interface.py
@@ -10,4 +10,3 @@ class RecordNicknameChangeUsecaseIf(
 ):
     """Interface for the use case that records nickname changes."""
 
-    pass

--- a/src/system/usecase/nickname/record_nickname_change.py
+++ b/src/system/usecase/nickname/record_nickname_change.py
@@ -10,15 +10,15 @@ from src.system.domain.interface.repository.user import UserRepository
 from src.system.domain.model.nickname import NicknameChangelog
 from src.system.domain.model.user import User
 from src.system.domain.value.nickname import (
-    NicknameChangelogRecordID,
     NicknameChangelogCreatedAt,
+    NicknameChangelogRecordID,
     NicknameChangelogUserRecordID,
 )
 from src.system.domain.value.user import (
-    UserRecordID,
     UserCreatedAt,
-    UserUpdatedAt,
     UserMessengerRecordID,
+    UserRecordID,
+    UserUpdatedAt,
 )
 from src.system.usecase.nickname.dto import (
     RecordNicknameChangeRequest,

--- a/src/system/usecase/nickname/test_dto.py
+++ b/src/system/usecase/nickname/test_dto.py
@@ -1,7 +1,7 @@
 from src.system.domain.value.messenger import MessengerName
 from src.system.domain.value.nickname import (
-    NicknameChangelogBefore,
     NicknameChangelogAfter,
+    NicknameChangelogBefore,
 )
 from src.system.domain.value.user import UserID
 from src.system.usecase.nickname.dto import (

--- a/src/system/usecase/nickname/test_record_nickname_change.py
+++ b/src/system/usecase/nickname/test_record_nickname_change.py
@@ -5,33 +5,33 @@ import pytest
 from ulid import ULID
 
 from src.system.domain.interface.repository.common.response import (
-    RepositoryResponse,
-    RepositoryResultStatusEnum,
-    RepositoryResponseStatusEnum,
     RepositoryFailedResponseEnum,
+    RepositoryResponse,
+    RepositoryResponseStatusEnum,
+    RepositoryResultStatusEnum,
 )
 from src.system.domain.model.messenger import Messenger
 from src.system.domain.model.nickname import NicknameChangelog
 from src.system.domain.model.user import User
 from src.system.domain.value.messenger import (
-    MessengerRecordID,
     MessengerCreatedAt,
-    MessengerUpdatedAt,
     MessengerName,
+    MessengerRecordID,
+    MessengerUpdatedAt,
 )
 from src.system.domain.value.nickname import (
-    NicknameChangelogRecordID,
-    NicknameChangelogCreatedAt,
-    NicknameChangelogUserRecordID,
-    NicknameChangelogBefore,
     NicknameChangelogAfter,
+    NicknameChangelogBefore,
+    NicknameChangelogCreatedAt,
+    NicknameChangelogRecordID,
+    NicknameChangelogUserRecordID,
 )
 from src.system.domain.value.user import (
-    UserRecordID,
     UserCreatedAt,
-    UserUpdatedAt,
-    UserMessengerRecordID,
     UserID,
+    UserMessengerRecordID,
+    UserRecordID,
+    UserUpdatedAt,
 )
 from src.system.usecase.nickname.dto import RecordNicknameChangeRequest
 from src.system.usecase.nickname.record_nickname_change import (

--- a/src/system/usecase/nickname/test_record_nickname_change.py
+++ b/src/system/usecase/nickname/test_record_nickname_change.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -47,7 +47,7 @@ def test_ulid() -> ULID:
 
 @pytest.fixture
 def test_datetime() -> datetime:
-    return datetime(2023, 1, 1, 12, 0, 0)
+    return datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture
@@ -144,7 +144,9 @@ class TestRecordNicknameChangeUsecaseExecute:
                 "src.system.usecase.nickname.record_nickname_change.generate_ulid"
             ) as mock_generate_ulid,
         ):
-            mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            mock_utcnow.return_value = datetime(
+                2023, 1, 1, 12, 0, 0, tzinfo=UTC
+            )
             mock_generate_ulid.return_value = generate_ulid()
 
             result = await usecase.execute(request_dto)
@@ -257,7 +259,9 @@ class TestRecordNicknameChangeUsecaseExecute:
                 "src.system.usecase.nickname.record_nickname_change.generate_ulid"
             ) as mock_generate_ulid,
         ):
-            mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            mock_utcnow.return_value = datetime(
+                2023, 1, 1, 12, 0, 0, tzinfo=UTC
+            )
             mock_generate_ulid.return_value = generate_ulid()
 
             result = await usecase.execute(request_dto)
@@ -305,7 +309,9 @@ class TestRecordNicknameChangeUsecaseExecute:
                 "src.system.usecase.nickname.record_nickname_change.generate_ulid"
             ) as mock_generate_ulid,
         ):
-            mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            mock_utcnow.return_value = datetime(
+                2023, 1, 1, 12, 0, 0, tzinfo=UTC
+            )
             mock_generate_ulid.return_value = generate_ulid()
 
             result = await usecase.execute(request_dto)
@@ -363,7 +369,9 @@ class TestRecordNicknameChangeUsecaseExecute:
                 "src.system.usecase.nickname.record_nickname_change.generate_ulid"
             ) as mock_generate_ulid,
         ):
-            mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            mock_utcnow.return_value = datetime(
+                2023, 1, 1, 12, 0, 0, tzinfo=UTC
+            )
             mock_generate_ulid.return_value = generate_ulid()
 
             result = await usecase.execute(request_dto)

--- a/src/system/util/datetime.py
+++ b/src/system/util/datetime.py
@@ -2,4 +2,4 @@ import datetime
 
 
 def utcnow() -> datetime.datetime:
-    return datetime.datetime.now(datetime.timezone.utc)
+    return datetime.datetime.now(datetime.UTC)

--- a/src/system/util/id.py
+++ b/src/system/util/id.py
@@ -5,5 +5,7 @@ from ulid import ULID
 from src.system.util.datetime import utcnow
 
 
-def generate_ulid(value: datetime.datetime = utcnow()) -> ULID:
+def generate_ulid(value: datetime.datetime | None = None) -> ULID:
+    value = value or utcnow()
+
     return ULID.from_datetime(value)

--- a/src/system/util/id.py
+++ b/src/system/util/id.py
@@ -1,5 +1,7 @@
 import datetime
+
 from ulid import ULID
+
 from src.system.util.datetime import utcnow
 
 


### PR DESCRIPTION
## Summary

- Evaluates ULID timestamps when `generate_ulid` is called, avoiding a stale default timestamp.
- Modernizes the DI binding generic declaration and explicitly marks test binding collections as class variables.
- Narrows SQLAlchemy repository error handling to `SQLAlchemyError` and updates failure-path tests accordingly.
- Makes test timestamps timezone-aware (UTC).

## Root cause

Several Ruff rules required changes that cannot be applied safely by `ruff check --fix`, including mutable/default-time evaluation, generic declaration style, blind
exception handling, and timezone-naive datetimes.

## Validation

- `uv run ruff check . --fix`
- `uv run pytest`

Result: 104 passed.
