### PR TITLE
fix: use supported uv Debian image tag

### DIFF
--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -57,7 +57,7 @@ FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_source
 # Base builder: installs Python, creates venv, installs production dependencies
 # NOTE: Source code is NOT copied here to maximize cache efficiency
 # Uses debian-based uv image for build tools required during dependency installation
-FROM ghcr.io/astral-sh/uv:${UV_VERSION}-bookworm-slim AS base_builder
+FROM ghcr.io/astral-sh/uv:${UV_VERSION}-debian-slim AS base_builder
 
 # Inherit global ARGs
 ARG PYTHON_VERSION


### PR DESCRIPTION
## Summary

- replace the removed `bookworm-slim` uv image suffix with `debian-slim`
- retain the `UV_VERSION` argument so Renovate continues to manage uv version updates

## Root cause

Renovate updated `UV_VERSION` to `0.11`, but `ghcr.io/astral-sh/uv:0.11-bookworm-slim` is no longer published. The resulting Docker build fails while resolving the base builder image.

## Validation

- `docker build --target base_builder --file docker/python/Dockerfile --tag imperial-household-agency:uv-base-builder-check .`
- `docker build --target base_builder --build-arg UV_VERSION=0.11 --file docker/python/Dockerfile --tag imperial-household-agency:uv-0.11-base-builder-check .`